### PR TITLE
ellipsis bug fix

### DIFF
--- a/app/src/main/java/com/hootsuite/nachos/sample/MainActivity.java
+++ b/app/src/main/java/com/hootsuite/nachos/sample/MainActivity.java
@@ -77,6 +77,10 @@ public class MainActivity extends AppCompatActivity {
         ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_dropdown_item_1line, SUGGESTIONS);
         nachoTextView.setAdapter(adapter);
         nachoTextView.setIllegalCharacters('\"');
+        List<String> chips = new ArrayList<>();
+        chips.add("Doritos");
+        chips.add("Lays");
+        nachoTextView.setText(chips);
         nachoTextView.addChipTerminator('\n', ChipTerminatorHandler.BEHAVIOR_CHIPIFY_ALL);
         nachoTextView.addChipTerminator(' ', ChipTerminatorHandler.BEHAVIOR_CHIPIFY_TO_TERMINATOR);
         nachoTextView.addChipTerminator(';', ChipTerminatorHandler.BEHAVIOR_CHIPIFY_CURRENT_TOKEN);

--- a/app/src/main/java/com/hootsuite/nachos/sample/MainActivity.java
+++ b/app/src/main/java/com/hootsuite/nachos/sample/MainActivity.java
@@ -77,10 +77,6 @@ public class MainActivity extends AppCompatActivity {
         ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_dropdown_item_1line, SUGGESTIONS);
         nachoTextView.setAdapter(adapter);
         nachoTextView.setIllegalCharacters('\"');
-        List<String> chips = new ArrayList<>();
-        chips.add("Doritos");
-        chips.add("Lays");
-        nachoTextView.setText(chips);
         nachoTextView.addChipTerminator('\n', ChipTerminatorHandler.BEHAVIOR_CHIPIFY_ALL);
         nachoTextView.addChipTerminator(' ', ChipTerminatorHandler.BEHAVIOR_CHIPIFY_TO_TERMINATOR);
         nachoTextView.addChipTerminator(';', ChipTerminatorHandler.BEHAVIOR_CHIPIFY_CURRENT_TOKEN);

--- a/lib/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/lib/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -5,6 +5,7 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
+import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
@@ -229,6 +230,12 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
             invalidateChips();
             mMeasured = true;
         }
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        invalidateChips();
     }
 
     /**

--- a/lib/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/lib/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -171,6 +171,9 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
     // Measurement
     private boolean mMeasured;
 
+    // Layout
+    private boolean mLayoutComplete;
+
     public NachoTextView(Context context) {
         super(context);
         init(null);
@@ -234,7 +237,11 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        invalidateChips();
+
+        if (!mLayoutComplete) {
+            invalidateChips();
+            mLayoutComplete = true;
+        }
     }
 
     /**

--- a/lib/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/lib/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -5,7 +5,6 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
-import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
@@ -233,8 +232,8 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
     }
 
     @Override
-    protected void onDraw(Canvas canvas) {
-        super.onDraw(canvas);
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
         invalidateChips();
     }
 


### PR DESCRIPTION
### Summary
The problem was that invalidateData(), which gets the width of the EditText and uses it to configure the chip width, is only called in the View lifecycle before the layout width of the TextView is set. getWidth() always returned 0. I ended up overriding the onDraw() method and called invalidateData() from there as well, since onDraw() is called in the lifecycle after the View's layout is set.
### Test Plan
In the nachos test app, set a few nachos that should appear as soon as the app launches and check that the chips do not ellipsis. Make sure that everything else works too.
### Reviewer
@simon-tse-hs @neil-power-hs @wesley-alcock-hs 
### JIRA Ticket
https://jira.hootsuitemedia.com/browse/AND-4503

