### PR TITLE
Include stateSet in re-creation of chip.

### DIFF
--- a/lib/src/main/java/com/hootsuite/nachos/chip/ChipSpan.java
+++ b/lib/src/main/java/com/hootsuite/nachos/chip/ChipSpan.java
@@ -139,6 +139,8 @@ public class ChipSpan extends ImageSpan implements Chip {
 
         mChipVerticalSpacing =chipSpan.mChipVerticalSpacing;
         mChipHeight = chipSpan.mChipHeight;
+
+        stateSet = chipSpan.stateSet;
     }
 
     @Override


### PR DESCRIPTION
With the current implementation, stateSet is lost on invalidateChips so the background ColorStateList will only ever use the single default color.