### PR TITLE
Catching a frequent NPE caused mostly by Samsung devices

### DIFF
--- a/lib/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/lib/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -17,6 +17,7 @@ import android.text.Layout;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.Pair;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -524,7 +525,18 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
                 mOnChipClickListener.onChipClick(touchedChip, event);
             }
         }
-        return wasHandled || super.onTouchEvent(event);
+
+        // Getting NullPointerException inside Editor.updateFloatingToolbarVisibility (Editor.java:1520)
+        // primarily seen in Samsung Nougat devices.
+        boolean superOnTouch = false;
+        try {
+            superOnTouch = super.onTouchEvent(event);
+        } catch (NullPointerException e) {
+            Log.w("Nacho", String.format("Error during touch event of type [%d]", event.getAction()), e);
+            // can't handle or reproduce, but will monitor the error
+        }
+
+        return wasHandled || superOnTouch;
     }
 
     @Nullable


### PR DESCRIPTION
### Summary
- In production, we frequently got a crash for a `NullPointerException` as a result of a `super.onTouchEvent()` call inside of Android. It was mostly happening on Samsung, and then Oppo as secondary.  Android Nougat was the major target as well.
- Haven't be able to reproduce, but we'd like to get a little more data to find out what is going on without disturbing the user

### Test Plan
- Type on the sample apps to create chips and free hanging un chipped tokens. Tap and drag finger around the chips to see if they cause a problem.
- Delete chips by tapping on them
- Delete chips by backspacing into them
