### PR TITLE
Check indices in beforeTextChanged

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.1.1
+VERSION_NAME=1.1.2
 
 POM_ARTIFACT_ID=nachos
 GROUP=com.hootsuite.android

--- a/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -823,7 +823,9 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
         }
 
         // Handle an illegal or chip terminator character
-        handleTextChanged(mTextChangedStart, mTextChangedEnd);
+        if (message.length() >= mTextChangedEnd && message.length() >= mTextChangedStart) {
+            handleTextChanged(mTextChangedStart, mTextChangedEnd);
+        }
 
         endUnwatchedTextChange();
     }


### PR DESCRIPTION
### Summary
Added a check for indices from the beforeTextChanged to handle the case where a chip is deleted and the indices are no longer valid
### Test Plan
Pull the changes into the main Hootsuite app, then create several chips using the shorten url button, delete them and observe the behaviour (shouldn't crash). Create chips using Mentions and observe the same behaviour. Confirm that Query Builder still does all its expected functionality as well as other compose functionality (robust run-through of various typing behaviour)
