### PR TITLE
Update Gradle to use implementation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add this line to your module level build.gradle:
 
 ```groovy
 dependencies {
-    compile "com.hootsuite.android:nachos:1.1.1"
+    implementation "com.hootsuite.android:nachos:1.1.1"
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,5 +23,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':nachos')
     implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibVersion"
-    implementation 'com.jakewharton:butterknife:7.0.1'
+    implementation 'com.jakewharton:butterknife:8.8.1'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':nachos')
-    compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibVersion"
-    compile 'com.jakewharton:butterknife:7.0.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':nachos')
+    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibVersion"
+    implementation 'com.jakewharton:butterknife:7.0.1'
 }

--- a/app/src/main/java/com/hootsuite/nachos/sample/MainActivity.java
+++ b/app/src/main/java/com/hootsuite/nachos/sample/MainActivity.java
@@ -26,7 +26,7 @@ import com.hootsuite.nachos.validator.ChipifyingNachoValidator;
 import java.util.ArrayList;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 
@@ -35,11 +35,11 @@ public class MainActivity extends AppCompatActivity {
     private static String TAG = "Nachos";
     private static String[] SUGGESTIONS = new String[]{"Nachos", "Chip", "Tortilla Chips", "Melted Cheese", "Salsa", "Guacamole", "Cheddar", "Mozzarella", "Mexico", "Jalapeno"};
 
-    @Bind(R.id.info_body)
+    @BindView(R.id.info_body)
     TextView mInfoBodyView;
-    @Bind(R.id.nacho_text_view)
+    @BindView(R.id.nacho_text_view)
     NachoTextView mNachoTextView;
-    @Bind(R.id.nacho_text_view_with_icons)
+    @BindView(R.id.nacho_text_view_with_icons)
     NachoTextView mNachoTextViewWithIcons;
 
     @SuppressWarnings("deprecation")

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
     ext {
         minSdkVersion = 15
-        compileSdkVersion = 25
-        targetSdkVersion = 25
+        compileSdkVersion = 27
+        targetSdkVersion = 27
 
-        buildToolsVersion = "25.0.2"
-        supportLibVersion = "25.3.0"
+        buildToolsVersion = "27.0.3"
+        supportLibVersion = "27.1.1"
 
         gradleVersion = "2.3.0"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         buildToolsVersion = "27.0.3"
         supportLibVersion = "27.1.1"
 
-        gradleVersion = "2.3.0"
+        gradleVersion = "3.1.1"
     }
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         gradleVersion = "2.3.0"
     }
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -21,6 +22,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenLocal()
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 07 09:59:58 PST 2017
+#Fri Apr 20 12:10:40 JST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/nachos/build.gradle
+++ b/nachos/build.gradle
@@ -43,11 +43,11 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:support-compat:$rootProject.ext.supportLibVersion"
-    testCompile 'org.robolectric:robolectric:3.1'
-    testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile('com.squareup.assertj:assertj-android:1.1.0') {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:support-compat:$rootProject.ext.supportLibVersion"
+    testImplementation 'org.robolectric:robolectric:3.1'
+    testImplementation 'org.mockito:mockito-core:1.9.5'
+    testImplementation('com.squareup.assertj:assertj-android:1.1.0') {
         exclude group: 'org.mockito', module: 'mockito-core'
     }
 }


### PR DESCRIPTION
### Summary
Currently, Gradle will display the following error after compiling the project:
```
Configuration 'compile' is obsolete and has been replaced with 'implementation'.
It will be removed at the end of 2018
```
This PR updates Gradle and the Android Gradle Plugin in order to fix this.

The ButterKnife library had to be updated, because of the [requirement of annotation processors](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#annotationProcessor_config) in the new version of the Android Gradle Plugin.

### Test Plan
No specific tests were required and all current tests are passing.
