### PR TITLE
White color is being ignored

### DIFF
--- a/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -5,6 +5,7 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
@@ -123,7 +124,7 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
     // UI Attributes
     private int mChipSpacing = -1;
     private ColorStateList mChipBackground = null;
-    private int mChipTextColor = -1;
+    private int mChipTextColor = Color.TRANSPARENT;
     private int mChipTextSize = -1;
     private int mChipHeight = -1;
     private int mChipVerticalSpacing = -1;
@@ -195,7 +196,7 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
             try {
                 mChipSpacing = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipSpacing, -1);
                 mChipBackground = attributes.getColorStateList(R.styleable.NachoTextView_chipBackground);
-                mChipTextColor = attributes.getColor(R.styleable.NachoTextView_chipTextColor, -1);
+                mChipTextColor = attributes.getColor(R.styleable.NachoTextView_chipTextColor, Color.TRANSPARENT);
                 mChipTextSize = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipTextSize, -1);
                 mChipHeight = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipHeight, -1);
                 mChipVerticalSpacing = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipVerticalSpacing, -1);

--- a/nachos/src/main/java/com/hootsuite/nachos/chip/ChipSpanChipCreator.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/chip/ChipSpanChipCreator.java
@@ -2,6 +2,7 @@ package com.hootsuite.nachos.chip;
 
 import android.content.Context;
 import android.content.res.ColorStateList;
+import android.graphics.Color;
 import android.support.annotation.NonNull;
 
 import com.hootsuite.nachos.ChipConfiguration;
@@ -35,7 +36,7 @@ public class ChipSpanChipCreator implements ChipCreator<ChipSpan> {
         if (chipBackground != null) {
             chip.setBackgroundColor(chipBackground);
         }
-        if (chipTextColor != -1) {
+        if (chipTextColor != Color.TRANSPARENT) {
             chip.setTextColor(chipTextColor);
         }
         if (chipTextSize != -1) {


### PR DESCRIPTION
### Summary
`0xFF` will equal to `-1` (signed decimal), which will cause the condition `chipTextColor != -1` to be `false` when using the white color for text. Set the default text color to transparent and compare against it to avoid the issue.

### Test Plan
No specific tests are required.
