### PR TITLE
StringOutOfBoundException fix - from Twistle

### DIFF
--- a/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -783,6 +783,14 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
         int end = getSelectionEnd();
         Editable editable = getText();
         int start = mChipTokenizer.findTokenStart(editable, end);
+
+        // guard against java.lang.StringIndexOutOfBoundsException
+        start = Math.min(Math.max(0, start), editable.length());
+        end = Math.min(Math.max(0, end), editable.length());
+        if (end < start) {
+            end = start;
+        }
+
         editable.replace(start, end, mChipTokenizer.terminateToken(text, data));
 
         endUnwatchedTextChange();


### PR DESCRIPTION
### Summary
Thanks to the fix from Twistle at
https://github.com/twistle/nachos/commit/63f9c089ad6b05c9a5a23371f0c63cc88a5e556c

This should fix a StringOutOfBoundException when backspacing in the ChipTextView

