### PR TITLE
PUB-13404: Update chipSpacing to support lib 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Include a `NachoTextView` in your xml layout as follows:
 
 #### <a name="TOC-BasicUsage-UICustomization"></a>Customizing the UI ####
 NachoTextView offers several custom attributes that allow you to control the appearance of the chips it creates:
-* `chipSpacing` - The horizontal space between chips
+* `chipHorizontalSpacing` - The horizontal space between chips
 * `chipBackground` - The background color of the chip, can be a ColorStateList to change color when the chip is clicked
 * `chipCornerRadius` - The corner radius of the chip background
 * `chipTextColor` - The color of the chip text
@@ -91,7 +91,7 @@ Use these attributes as follows:
     android:id="@+id/nacho_text_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:chipSpacing="2dp"
+    app:chipHorizontalSpacing="2dp"
     app:chipBackground="@color/chip_background"
     app:chipTextColor="@color/cheddar"
     app:chipTextSize="16dp"

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
     ext {
         minSdkVersion = 15
-        compileSdkVersion = 27
-        targetSdkVersion = 27
+        compileSdkVersion = 28
+        targetSdkVersion = 28
 
-        buildToolsVersion = "27.0.3"
-        supportLibVersion = "27.1.1"
+        buildToolsVersion = "28.0.3"
+        supportLibVersion = "28.0.0"
 
         gradleVersion = "3.1.3"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.1.2
+VERSION_NAME=1.1.3
 
 POM_ARTIFACT_ID=nachos
 GROUP=com.hootsuite.android

--- a/nachos/src/main/java/com/hootsuite/nachos/ChipConfiguration.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/ChipConfiguration.java
@@ -4,7 +4,7 @@ import android.content.res.ColorStateList;
 
 public class ChipConfiguration {
 
-    private final int mChipSpacing;
+    private final int mChipHorizontalSpacing;
     private final ColorStateList mChipBackground;
     private final int mChipCornerRadius;
     private final int mChipTextColor;
@@ -17,7 +17,7 @@ public class ChipConfiguration {
      * Creates a new ChipConfiguration. You can pass in {@code -1} or {@code null} for any of the parameters to indicate that parameter should be
      * ignored.
      *
-     * @param chipSpacing         the amount of horizontal space (in pixels) to put between consecutive chips
+     * @param chipHorizontalSpacing         the amount of horizontal space (in pixels) to put between consecutive chips
      * @param chipBackground      the {@link ColorStateList} to set as the background of the chips
      * @param chipCornerRadius    the corner radius of the chip background, in pixels
      * @param chipTextColor       the color to set as the text color of the chips
@@ -26,7 +26,7 @@ public class ChipConfiguration {
      * @param chipVerticalSpacing the amount of vertical space (in pixels) to put between chips on consecutive lines
      * @param maxAvailableWidth   the maximum available with for a chip (the width of a full line of text in the text view)
      */
-    ChipConfiguration(int chipSpacing,
+    ChipConfiguration(int chipHorizontalSpacing,
                       ColorStateList chipBackground,
                       int chipCornerRadius,
                       int chipTextColor,
@@ -34,7 +34,7 @@ public class ChipConfiguration {
                       int chipHeight,
                       int chipVerticalSpacing,
                       int maxAvailableWidth) {
-        mChipSpacing = chipSpacing;
+        mChipHorizontalSpacing = chipHorizontalSpacing;
         mChipBackground = chipBackground;
         mChipCornerRadius = chipCornerRadius;
         mChipTextColor = chipTextColor;
@@ -44,8 +44,8 @@ public class ChipConfiguration {
         mMaxAvailableWidth = maxAvailableWidth;
     }
 
-    public int getChipSpacing() {
-        return mChipSpacing;
+    public int getChipHorizontalSpacing() {
+        return mChipHorizontalSpacing;
     }
 
     public ColorStateList getChipBackground() {

--- a/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -69,7 +69,7 @@ import java.util.Map;
  * <h1>UI Customization</h1>
  *     This view defines six custom attributes (all of which are optional):
  *     <ul>
- *         <li>chipSpacing - the horizontal space between chips</li>
+ *         <li>chipHorizontalSpacing - the horizontal space between chips</li>
  *         <li>chipBackground - the background color of the chip</li>
  *         <li>chipCornerRadius - the corner radius of the chip background</li>
  *         <li>chipTextColor - the color of the chip text</li>
@@ -125,7 +125,7 @@ import java.util.Map;
 public class NachoTextView extends MultiAutoCompleteTextView implements TextWatcher, AdapterView.OnItemClickListener {
 
     // UI Attributes
-    private int mChipSpacing = -1;
+    private int mChipHorizontalSpacing = -1;
     private ColorStateList mChipBackground = null;
     private int mChipCornerRadius = -1;
     private int mChipTextColor = Color.TRANSPARENT;
@@ -198,7 +198,7 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
                     R.style.DefaultChipSuggestionTextView);
 
             try {
-                mChipSpacing = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipSpacing, -1);
+                mChipHorizontalSpacing = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipHorizontalSpacing, -1);
                 mChipBackground = attributes.getColorStateList(R.styleable.NachoTextView_chipBackground);
                 mChipCornerRadius = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipCornerRadius, -1);
                 mChipTextColor = attributes.getColor(R.styleable.NachoTextView_chipTextColor, Color.TRANSPARENT);
@@ -291,12 +291,12 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
         updatePadding();
     }
 
-    public int getChipSpacing() {
-        return mChipSpacing;
+    public int getChipHorizontalSpacing() {
+        return mChipHorizontalSpacing;
     }
 
-    public void setChipSpacing(@DimenRes int chipSpacingResId) {
-        mChipSpacing = getContext().getResources().getDimensionPixelSize(chipSpacingResId);
+    public void setChipHorizontalSpacing(@DimenRes int chipHorizontalSpacingResId) {
+        mChipHorizontalSpacing = getContext().getResources().getDimensionPixelSize(chipHorizontalSpacingResId);
         invalidateChips();
     }
 
@@ -469,7 +469,7 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
             Editable text = getText();
             int availableWidth = getWidth() - getCompoundPaddingLeft() - getCompoundPaddingRight();
             ChipConfiguration configuration = new ChipConfiguration(
-                    mChipSpacing,
+                    mChipHorizontalSpacing,
                     mChipBackground,
                     mChipCornerRadius,
                     mChipTextColor,

--- a/nachos/src/main/java/com/hootsuite/nachos/chip/ChipSpanChipCreator.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/chip/ChipSpanChipCreator.java
@@ -21,7 +21,7 @@ public class ChipSpanChipCreator implements ChipCreator<ChipSpan> {
 
     @Override
     public void configureChip(@NonNull ChipSpan chip, @NonNull ChipConfiguration chipConfiguration) {
-        int chipSpacing = chipConfiguration.getChipSpacing();
+        int chipHorizontalSpacing = chipConfiguration.getChipHorizontalSpacing();
         ColorStateList chipBackground = chipConfiguration.getChipBackground();
         int chipCornerRadius = chipConfiguration.getChipCornerRadius();
         int chipTextColor = chipConfiguration.getChipTextColor();
@@ -30,9 +30,9 @@ public class ChipSpanChipCreator implements ChipCreator<ChipSpan> {
         int chipVerticalSpacing = chipConfiguration.getChipVerticalSpacing();
         int maxAvailableWidth = chipConfiguration.getMaxAvailableWidth();
 
-        if (chipSpacing != -1) {
-            chip.setLeftMargin(chipSpacing / 2);
-            chip.setRightMargin(chipSpacing / 2);
+        if (chipHorizontalSpacing != -1) {
+            chip.setLeftMargin(chipHorizontalSpacing / 2);
+            chip.setRightMargin(chipHorizontalSpacing / 2);
         }
         if (chipBackground != null) {
             chip.setBackgroundColor(chipBackground);

--- a/nachos/src/main/res/values/attrs.xml
+++ b/nachos/src/main/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="NachoTextView">
-        <attr name="chipSpacing" format="reference|dimension" />
+        <attr name="chipHorizontalSpacing" format="reference|dimension" />
         <attr name="chipBackground" format="reference|color"/>
         <attr name="chipCornerRadius" format="reference|dimension"/>
         <attr name="chipTextColor" format="reference|color"/>

--- a/nachos/src/main/res/values/styles.xml
+++ b/nachos/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <style name="DefaultChipSuggestionTextView">
-        <item name="chipSpacing">6dp</item>
+        <item name="chipHorizontalSpacing">6dp</item>
         <item name="chipBackground">@color/chip_material_background</item>
         <item name="chipTextSize">14sp</item>
         <item name="chipHeight">32dp</item>


### PR DESCRIPTION
### Summary
Update the chipSpacing attribute to chipHorizontalSpacing so as not to conflict with appcompat-v7-28.0.0.

error: duplicate value for resource 'attr/chipSpacing' with config ''.
Message{kind=ERROR, text=error: duplicate value for resource 'attr/chipSpacing' with config ''., sources=[C:\Users\Vivek Kaushik.gradle\caches\transforms-1\files-1.1\appcompat-v7-28.0.0-rc01.aar\664fa20d824381dbf468c0902e41e423\res\values\values.xml:1304:5-69], original message=, tool name=Optional.of(AAPT)}

### Test Plan
- Fire up the sample app or a consuming library and generate chips as you would, utilizing support library 28.0.0

