### PR TITLE
Nachos publishing uses gradle.properties values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
-VERSION_NAME=1.2.0 
+VERSION_NAME=1.2.0
 
 POM_ARTIFACT_ID=nachos
 GROUP=com.hootsuite.android
 
 POM_NAME=Nachos for Android
-POM_DESCRIPTION=An implementation of material chips on Android
-POM_SCM_URL=
-POM_SCM_CONNECTION=
-POM_SCM_DEV_CONNECTION=
+POM_DESCRIPTION=A library for Android that provides a custom TextView allowing users to enter text and create material chips in the text field.
+POM_SCM_URL=https://github.com/hootsuite/nachos
+POM_SCM_CONNECTION=https://github.com/hootsuite/nachos.git
+POM_SCM_DEV_CONNECTION=https://github.com/hootsuite/nachos.git
 POM_URL=
 
 POM_DEVELOPER_NAME=Hootsuite

--- a/nachos/build.gradle
+++ b/nachos/build.gradle
@@ -2,25 +2,25 @@ apply plugin: 'com.android.library'
 
 ext {
     bintrayRepo = 'maven'
-    bintrayName = 'nachos'
+    bintrayName = POM_ARTIFACT_ID
 
-    publishedGroupId = 'com.hootsuite.android'
-    libraryName = 'nachos'
-    artifact = 'nachos'
+    publishedGroupId = GROUP
+    libraryName = POM_ARTIFACT_ID
+    artifact = POM_ARTIFACT_ID
 
-    libraryDescription = 'A library for Android that provides a custom TextView allowing users to enter text and create material chips in the text field.'
+    libraryDescription = POM_DESCRIPTION
 
-    siteUrl = 'https://github.com/hootsuite/nachos'
-    gitUrl = 'https://github.com/hootsuite/nachos.git'
+    siteUrl = POM_SCM_URL
+    gitUrl = POM_SCM_CONNECTION
 
-    libraryVersion = '1.1.1'
+    libraryVersion = VERSION_NAME
 
-    developerId = 'hootsuite'
-    developerName = 'Hootsuite'
+    developerId = POM_DEVELOPER_ID
+    developerName = POM_DEVELOPER_NAME
     developerEmail = 'opensource@hootsuite.com'
 
-    licenseName = 'The Apache Software License, Version 2.0'
-    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    licenseName = POM_LICENCE_NAME
+    licenseUrl = POM_LICENCE_URL
     allLicenses = ["Apache-2.0"]
 }
 
@@ -45,8 +45,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "com.android.support:support-compat:$rootProject.ext.supportLibVersion"
-    testImplementation 'org.robolectric:robolectric:3.1'
-    testImplementation 'org.mockito:mockito-core:1.9.5'
+    testImplementation 'org.robolectric:robolectric:4.0.2'
+    testImplementation 'org.mockito:mockito-core:2.21.0'
     testImplementation('com.squareup.assertj:assertj-android:1.1.0') {
         exclude group: 'org.mockito', module: 'mockito-core'
     }


### PR DESCRIPTION
### Summary
Realized when trying to publish a new version of Nachos, the values were duplicated in `gradle.properties` and `build.gradle`. This PR is trying to consolidate them together.
